### PR TITLE
Remove timezones from financial year settings

### DIFF
--- a/app/Http/Controllers/PreferencesController.php
+++ b/app/Http/Controllers/PreferencesController.php
@@ -277,11 +277,22 @@ class PreferencesController extends Controller
 
         // custom fiscal year
         $customFiscalYear  = 1 === (int) $request->get('customFiscalYear');
-        $string            = strtotime((string) $request->get('fiscalYearStart'));
-        if (false !== $string) {
-            $fiscalYearStart = Carbon::createFromTimestamp($string)->format('m-d');
-            Preferences::set('customFiscalYear', $customFiscalYear);
-            Preferences::set('fiscalYearStart', $fiscalYearStart);
+        $fiscalYearStartInput = (string) $request->get('fiscalYearStart');
+        if (!empty($fiscalYearStartInput)) {
+            try {
+                // Parse the date input directly without timezone conversion
+                $fiscalYearStart = Carbon::createFromFormat('Y-m-d', $fiscalYearStartInput)->format('m-d');
+                Preferences::set('customFiscalYear', $customFiscalYear);
+                Preferences::set('fiscalYearStart', $fiscalYearStart);
+            } catch (\Exception $e) {
+                // Fallback to original method if direct parsing fails
+                $string = strtotime($fiscalYearStartInput);
+                if (false !== $string) {
+                    $fiscalYearStart = Carbon::createFromTimestamp($string)->format('m-d');
+                    Preferences::set('customFiscalYear', $customFiscalYear);
+                    Preferences::set('fiscalYearStart', $fiscalYearStart);
+                }
+            }
         }
 
         // save page size:


### PR DESCRIPTION
Setting a financial year gets confused when using a timezone, like UTC+12. 

For example, setting 1/07/2025 in the preferences, will immediately revert to 30/06/2025. Showing transactions on a particular date also get missed as timezones seem to play a role. 

The financial year date should be independent of timezones. 